### PR TITLE
Count tests in progress bar

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,8 @@ async fn real_main() -> Result<()> {
     let progress_bar = if !options.no_progress {
         let bar = ProgressBar::new(1);
         bar.set_style(
-            indicatif::ProgressStyle::with_template("{wide_bar} job {pos}/{len}{msg} ({eta})").unwrap(),
+            indicatif::ProgressStyle::with_template("{wide_bar} test {pos}/{len}{msg} ({eta})")
+                .unwrap(),
         );
         bar.enable_steady_tick(std::time::Duration::from_secs(1));
         bar

--- a/src/slog_pg.rs
+++ b/src/slog_pg.rs
@@ -1,9 +1,12 @@
 //! A slog term decorator that prints log messages to a progress bar.
 
+use indicatif::ProgressBar;
 use slog::{OwnedKVList, Record};
 use slog_term::{Decorator, RecordDecorator};
 
-pub struct ProgressBarDecorator;
+pub struct ProgressBarDecorator {
+    pub progress_bar: ProgressBar,
+}
 
 struct ProgressBarRecordDecorator<'a>(&'a mut Vec<u8>);
 
@@ -16,12 +19,13 @@ impl Decorator for ProgressBarDecorator {
     ) -> std::io::Result<()> {
         let mut rec = Vec::new();
         f(&mut ProgressBarRecordDecorator(&mut rec))?;
-        crate::PROGRESS_BAR.println(String::from_utf8(rec).map_err(|e| {
-            std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!("Cannot convert log message to string: {e}"),
-            )
-        })?);
+        self.progress_bar
+            .println(String::from_utf8(rec).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("Cannot convert log message to string: {e}"),
+                )
+            })?);
         Ok(())
     }
 }

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -206,6 +206,7 @@ mod tests {
         assert_eq!(tests.len(), 18, "Test size does not match");
 
         let mut summary = Summary::default();
+        let pb = ProgressBar::hidden();
         run_tests_parallel(
             &logger,
             &tests,
@@ -213,7 +214,7 @@ mod tests {
             &run_options,
             None,
             num_cpus::get(),
-            None,
+            &pb,
         )
         .await;
 


### PR DESCRIPTION
Count tests instead of jobs.
Make the progress bar mandatory, so we can use
its position and length to keep track of the tests, 
even if we do not output the bar.